### PR TITLE
Some optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ AutoStaker for MirrorProtocol
    MNEMONIC_INDEX=0
    COIN_TYPE=330
    ```  
+   > You can leave `MNEMONIC=""` and then run the program using `npm start -- --mnemonic="your mnemonic"`
    
    Or, you can use .env_example to create .env
    ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -6335,8 +6335,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "dependencies": {
     "@mirror-protocol/mirror.js": "^1.1.2",
     "@terra-money/terra.js": "^1.0.1",
-    "dotenv": "^8.2.0"
+    "dotenv": "^8.2.0",
+    "minimist": "^1.2.5"
   }
 }

--- a/src/AutoStaker.ts
+++ b/src/AutoStaker.ts
@@ -1,3 +1,5 @@
+const args = require('minimist')(process.argv.slice(2));
+
 import { Mirror } from '@mirror-protocol/mirror.js';
 import {
   MnemonicKey,
@@ -10,7 +12,8 @@ import {
 } from '@terra-money/terra.js';
 
 const MNEMONIC =
-  process.env.MNEMONIC != '' ? process.env.MNEMONIC : process.argv[3];
+  process.env.MNEMONIC != '' ? process.env.MNEMONIC : args.mnemonic;
+
 const MNEMONIC_INDEX = parseInt(process.env.MNEMONIC_INDEX || '0');
 const COIN_TYPE = parseInt(process.env.COIN_TYPE as string);
 

--- a/src/AutoStaker.ts
+++ b/src/AutoStaker.ts
@@ -92,7 +92,7 @@ export default class AutoStaker {
 
     const balanceResponse = await this.mirror.mirrorToken.getBalance();
     const balance = new Int(balanceResponse.balance);
-    const sellAmount = new Int(balance.divToInt(2));
+    const sellAmount = new Int(balance.divToInt(1.9));
     const mirrorAmount = balance.sub(sellAmount);
 
     console.log('Swap half rewards to UST');

--- a/src/AutoStaker.ts
+++ b/src/AutoStaker.ts
@@ -9,7 +9,8 @@ import {
   int
 } from '@terra-money/terra.js';
 
-const MNEMONIC = process.env.MNEMONIC;
+const MNEMONIC =
+  process.env.MNEMONIC != '' ? process.env.MNEMONIC : process.argv[3];
 const MNEMONIC_INDEX = parseInt(process.env.MNEMONIC_INDEX || '0');
 const COIN_TYPE = parseInt(process.env.COIN_TYPE as string);
 

--- a/src/AutoStaker.ts
+++ b/src/AutoStaker.ts
@@ -79,7 +79,11 @@ export default class AutoStaker {
     );
 
     // if no rewards exists, skip procedure
-    if (poolInfo.reward_index == rewardInfoResponse.reward_infos[0].index) {
+    if (
+      rewardInfoResponse.reward_infos.length == 0 ||
+      poolInfo.reward_index == rewardInfoResponse.reward_infos[0].index
+    ) {
+      console.log('No rewards');
       return;
     }
 

--- a/src/tempCodeRunnerFile.ts
+++ b/src/tempCodeRunnerFile.ts
@@ -1,0 +1,1 @@
+rewardInfoResponse.reward_infos;

--- a/src/tempCodeRunnerFile.ts
+++ b/src/tempCodeRunnerFile.ts
@@ -1,1 +1,0 @@
-rewardInfoResponse.reward_infos;


### PR DESCRIPTION
- Converts  ≃53% (instead of 50%) of the MIR into UST to cover the transaction fees
- Prevent `Cannot read property 'index' of undefined` error if the account has never had rewards